### PR TITLE
Updated pom.xml to build module with lastest serentiy modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,25 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <serenity.version>1.1.26-rc.1</serenity.version>
-        <serenity.maven.version>1.1.26-rc.1</serenity.maven.version>
-        <serenity.cucumber.version>1.1.26-rc.1</serenity.cucumber.version>
-        <serenity.jbehave.version>1.1.26-rc.1</serenity.jbehave.version>
+        <serenity.version>ProjectDependencyHelper-version</serenity.version>
+        <serenity.maven.version>ProjectDependencyHelper-version</serenity.maven.version>
+        <serenity.cucumber.version>ProjectDependencyHelper-version</serenity.cucumber.version>
+        <serenity.jbehave.version>ProjectDependencyHelper-version</serenity.jbehave.version>
     </properties>
-
+    <repositories>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>central</id>
+            <name>bintray</name>
+            <url>http://jcenter.bintray.com</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </releases>
+        </repository>
+    </repositories>
     <dependencies>
         <dependency>
             <groupId>net.serenity-bdd</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <serenity.version>ProjectDependencyHelper-version</serenity.version>
-        <serenity.maven.version>ProjectDependencyHelper-version</serenity.maven.version>
-        <serenity.cucumber.version>ProjectDependencyHelper-version</serenity.cucumber.version>
-        <serenity.jbehave.version>ProjectDependencyHelper-version</serenity.jbehave.version>
+        <serenity.version>1.1.26</serenity.version>
+        <serenity.maven.version>1.1.26</serenity.maven.version>
+        <serenity.cucumber.version>1.1.5</serenity.cucumber.version>
+        <serenity.jbehave.version>1.6.0</serenity.jbehave.version>
     </properties>
     <repositories>
         <repository>
@@ -43,7 +43,7 @@
         </dependency>
         <dependency>
             <groupId>net.serenity-bdd</groupId>
-            <artifactId>serenity-journey</artifactId>
+            <artifactId>serenity-screenplay</artifactId>
             <version>${serenity.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
#### Summary of this PR

Updated pom.xml to build module with lastest serentiy modules
#### Intended effect

Now it is possible to use serenity core 1.1.26
#### How should this be manually tested?

Just run guild
#### Side effects

N/A
#### Documentation

N/A
#### Relevant tickets

N/A
#### Screenshots (if appropriate)

N/A
